### PR TITLE
Add PyTorch MNIST model

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "workshops/max-pytorch-mnist"]
+	path = workshops/max-pytorch-mnist
+	url = https://github.com/xuhdev/max-pytorch-mnist


### PR DESCRIPTION
Did not add a full folder because a submodule is more convenient for users to
clone.